### PR TITLE
Sep 62  Wyszukiwanie wydarzeń po nazwie (frontend)

### DIFF
--- a/frontend/src/components/EventList.jsx
+++ b/frontend/src/components/EventList.jsx
@@ -7,6 +7,8 @@ export default function EventList() {
     const [events, setEvents] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [searchTerm, setSearchTerm] = useState("");
+
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -63,6 +65,17 @@ export default function EventList() {
 
     return (
         <div className="min-h-screen bg-gray-100 py-10 px-4 flex flex-col items-center">
+
+            <div className={"w-full max-w-6xl flex justify-end mb-6"}>
+                <input
+                    type={"text"}
+                    placeholder={"Szukaj po nazwie..."}
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className={"mb-6 px-4 py-2 border border-gray-300 rounded-md w-full max-w-md"}
+                />
+            </div>
+
             <h1 className="text-3xl font-bold text-amber-600 mb-8">
                 Nadchodzące wydarzenia
             </h1>
@@ -75,7 +88,9 @@ export default function EventList() {
                 <p className="text-gray-600">Brak wydarzeń do wyświetlenia.</p>
             ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl w-full">
-                    {events.map((event) => (
+                    {events
+                        .filter(event=>event.title.toLowerCase().includes(searchTerm.toLowerCase()))
+                        .map((event) => (
                         <div
                             key={event.id}
                             onClick={() => navigate(`/events/${event.id}`)}


### PR DESCRIPTION
🔧 Zmiany wprowadzone w tym PR:

    Dodano pole input do wyszukiwania wydarzeń po nazwie na stronie listy wydarzeń.

    Wyszukiwanie działa po stronie frontendu – lokalnie filtrowana jest lista pobranych wydarzeń.

    Stylizacja inputa zgodna z aktualnym layoutem (wyrównanie do prawej, dopasowany rozmiar i margines).

    Kod zoptymalizowany pod kątem przejrzystości i UX – brak zbędnych logów / nieużywanego kodu.

✅ Do sprawdzenia:

    Czy UI wygląda OK na desktopie.

    Czy filtrowanie działa zgodnie z oczekiwaniami (bez reloadu, dynamicznie).