### PR TITLE
Utworzenie raportu liczby zaplanowanych wydarzeń. Uwzględniono tylko …

### DIFF
--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
@@ -1,0 +1,31 @@
+package pl.uniwersytetkaliski.studenteventsplatform.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO.EventCountReportDTO;
+import pl.uniwersytetkaliski.studenteventsplatform.service.ReportService;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    @Autowired
+    private ReportService reportService;
+
+    @GetMapping("/event-count")
+    @PreAuthorize("hasRole('ADMIN')")
+    public EventCountReportDTO getEventCount(
+            @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromDate,
+            @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) LocalDateTime toDate
+    ) {
+        long count = reportService.countEventsBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
+        return new EventCountReportDTO(count);
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/EventCountReportDTO.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/EventCountReportDTO.java
@@ -1,0 +1,17 @@
+package pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO;
+
+public class EventCountReportDTO {
+    private long eventCount;
+
+    public EventCountReportDTO(long eventCount) {
+        this.eventCount = eventCount;
+    }
+
+    public long getEventCount() {
+        return eventCount;
+    }
+
+    public void setEventCount(long eventCount) {
+        this.eventCount = eventCount;
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/EventRepository.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/EventRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import pl.uniwersytetkaliski.studenteventsplatform.model.Event;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,6 +54,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 //    @Query("SELECT e FROM Event e LEFT JOIN FETCH e.participants WHERE e.id = :id")
     @Query("SELECT e FROM Event e LEFT JOIN FETCH e.userEvent ue LEFT JOIN FETCH ue.user WHERE e.id = :id")
     Optional<Event> findByIdWithParticipants(@Param("id") Long id);
+
+    long countByStartDateBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate);
 }
 
 

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
@@ -1,0 +1,20 @@
+package pl.uniwersytetkaliski.studenteventsplatform.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.uniwersytetkaliski.studenteventsplatform.repository.EventRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class ReportService implements ReportServiceInterface {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Override
+    public long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate) {
+        return eventRepository.countByStartDateBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
@@ -1,0 +1,8 @@
+package pl.uniwersytetkaliski.studenteventsplatform.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface ReportServiceInterface {
+    long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate);
+}


### PR DESCRIPTION
[SEP-104] Raport liczby wydarzeń – filtracja po zaakceptowanych i nieusuniętych. Funkcjonalność dla roli ADMIN.

W ramach zadania SEP-104 utworzono raport liczby wydarzeń zwracanych przez endpoint:
GET /api/reports/event-count?fromDate=...&toDate=...

Raport zlicza tylko zaakceptowane wydarzenia (accepted = true) oraz pomija usunięte (deleted = false)

Przetestowano lokalnie z danymi testowymi - działa zgodnie z oczekiwaniami.

Prośba o code review i ewentualne uwagi.