### PR TITLE
[SEP-106] Raport: łączna liczba uczestników w danym okresie

### DIFF
--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
@@ -1,0 +1,31 @@
+package pl.uniwersytetkaliski.studenteventsplatform.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO.EventCountReportDTO;
+import pl.uniwersytetkaliski.studenteventsplatform.service.ReportService;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    @Autowired
+    private ReportService reportService;
+
+    @GetMapping("/event-count")
+    @PreAuthorize("hasRole('ADMIN')")
+    public EventCountReportDTO getEventCount(
+            @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromDate,
+            @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME) LocalDateTime toDate
+    ) {
+        long count = reportService.countEventsBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
+        return new EventCountReportDTO(count);
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/controller/ReportController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO.EventCountReportDTO;
+import pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO.ParticipantCountReportDTO;
 import pl.uniwersytetkaliski.studenteventsplatform.service.ReportService;
 
 import java.time.LocalDateTime;
@@ -27,5 +28,16 @@ public class ReportController {
     ) {
         long count = reportService.countEventsBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
         return new EventCountReportDTO(count);
+    }
+
+
+    @GetMapping("/participant-count")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ParticipantCountReportDTO getParticipantCount(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime fromDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime toDate
+    ) {
+        long count = reportService.countParticipantsBetween(fromDate, toDate);
+        return new ParticipantCountReportDTO(count);
     }
 }

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/EventCountReportDTO.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/EventCountReportDTO.java
@@ -1,0 +1,17 @@
+package pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO;
+
+public class EventCountReportDTO {
+    private long eventCount;
+
+    public EventCountReportDTO(long eventCount) {
+        this.eventCount = eventCount;
+    }
+
+    public long getEventCount() {
+        return eventCount;
+    }
+
+    public void setEventCount(long eventCount) {
+        this.eventCount = eventCount;
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/ParticipantCountReportDTO.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/dto/reportDTO/ParticipantCountReportDTO.java
@@ -1,0 +1,17 @@
+package pl.uniwersytetkaliski.studenteventsplatform.dto.reportDTO;
+
+public class ParticipantCountReportDTO {
+    private long participantCount;
+
+    public ParticipantCountReportDTO(long participantCount) {
+        this.participantCount = participantCount;
+    }
+
+    public long getParticipantCount() {
+        return participantCount;
+    }
+
+    public void setParticipantCount(long participantCount) {
+        this.participantCount = participantCount;
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/EventRepository.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/EventRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import pl.uniwersytetkaliski.studenteventsplatform.model.Event;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,6 +54,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 //    @Query("SELECT e FROM Event e LEFT JOIN FETCH e.participants WHERE e.id = :id")
     @Query("SELECT e FROM Event e LEFT JOIN FETCH e.userEvent ue LEFT JOIN FETCH ue.user WHERE e.id = :id")
     Optional<Event> findByIdWithParticipants(@Param("id") Long id);
+
+    long countByStartDateBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate);
 }
 
 

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/UserEventRepository.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/repository/UserEventRepository.java
@@ -1,10 +1,13 @@
 package pl.uniwersytetkaliski.studenteventsplatform.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import pl.uniwersytetkaliski.studenteventsplatform.model.Event;
 import pl.uniwersytetkaliski.studenteventsplatform.model.User;
 import pl.uniwersytetkaliski.studenteventsplatform.model.UserEvent;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,4 +22,15 @@ public interface UserEventRepository extends JpaRepository<UserEvent,Long> {
     List<UserEvent> findByEvent_Id(long id);
 
     List<UserEvent> findByUser_Id(long userId);
+
+    @Query("""
+        SELECT count(ue)\s
+        FROM UserEvent ue
+        WHERE ue.event.startDate BETWEEN :from AND :to
+        AND ue.event.accepted = true\s
+        AND ue.event.deleted = false
+""")
+    long countParticipantBetweenDates(
+            @Param("from")LocalDateTime from,
+            @Param("to") LocalDateTime to);
 }

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
@@ -3,6 +3,7 @@ package pl.uniwersytetkaliski.studenteventsplatform.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import pl.uniwersytetkaliski.studenteventsplatform.repository.EventRepository;
+import pl.uniwersytetkaliski.studenteventsplatform.repository.UserEventRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,9 +13,16 @@ public class ReportService implements ReportServiceInterface {
 
     @Autowired
     private EventRepository eventRepository;
+    @Autowired
+    private UserEventRepository userEventRepository;
 
     @Override
     public long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate) {
         return eventRepository.countByStartDateBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
+    }
+
+    @Override
+    public long countParticipantsBetween(LocalDateTime fromDate, LocalDateTime toDate) {
+        return userEventRepository.countParticipantBetweenDates(fromDate, toDate);
     }
 }

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportService.java
@@ -1,0 +1,20 @@
+package pl.uniwersytetkaliski.studenteventsplatform.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import pl.uniwersytetkaliski.studenteventsplatform.repository.EventRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class ReportService implements ReportServiceInterface {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Override
+    public long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate) {
+        return eventRepository.countByStartDateBetweenAndDeletedFalseAndAcceptedTrue(fromDate, toDate);
+    }
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
@@ -1,0 +1,8 @@
+package pl.uniwersytetkaliski.studenteventsplatform.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface ReportServiceInterface {
+    long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate);
+}

--- a/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
+++ b/src/main/java/pl/uniwersytetkaliski/studenteventsplatform/service/ReportServiceInterface.java
@@ -5,4 +5,6 @@ import java.time.LocalDateTime;
 
 public interface ReportServiceInterface {
     long countEventsBetweenAndDeletedFalseAndAcceptedTrue(LocalDateTime fromDate, LocalDateTime toDate);
+
+    long countParticipantsBetween(LocalDateTime fromDate, LocalDateTime toDate);
 }


### PR DESCRIPTION
W ramach zadania SEP-106 dodano raport zwracający liczbę uczestników wydarzeń w określonym przedziale dat:
GET /api/reports/participant-count?fromDate=...&toDate=...

Uwzględniane są tylko wydarzenia zaakceptowane oraz nieusunięte. Dane są zliczane na podstawie encji UserEvent. 

Przetestowano lokalnie w Postmanie z użytkownikiem posiadającym rolę ADMIN (funkcjonalność jest przygotowana stricte pod tą rolę). Moje testy nie wykazały niepożądanych efektów.

Proszę o sprawdzenie i ewentualne uwagi.